### PR TITLE
Fix heron build POM file

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,18 @@ cd incubator-samoa
 mvn -Papex package
 ```
 
+### Heron mode
+
+Simply clone the repository and install SAMOA.
+
+```bash
+git clone http://git.apache.org/incubator-samoa.git
+cd incubator-samoa
+mvn -Pheron package
+```
+
+The deployable jar for SAMOA will be in `target/SAMOA-Heron-0.5.0-SNAPSHOT.jar`.
+
 ### Local mode
 
 If you want to test SAMOA in a local environment, simply clone the repository and install SAMOA.

--- a/pom.xml
+++ b/pom.xml
@@ -77,15 +77,6 @@
             </modules>
         </profile>
         <profile>
-            <id>heron</id>
-            <modules>
-                <module>samoa-instances</module>
-                <module>samoa-api</module>
-                <module>samoa-heron</module>
-                <module>samoa-test</module>
-            </modules>
-        </profile>
-        <profile>
             <id>apex</id>
             <modules>
                 <module>samoa-instances</module>

--- a/samoa-heron/pom.xml
+++ b/samoa-heron/pom.xml
@@ -51,49 +51,20 @@
     </repository>
   </repositories>
 
-    <dependencies>
-        <dependency>
-            <groupId>org.apache.samoa</groupId>
-            <artifactId>samoa-api</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.samoa</groupId>
-            <artifactId>samoa-test</artifactId>
-            <type>test-jar</type>
-            <classifier>test-jar-with-dependencies</classifier>
-            <version>${project.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.twitter.heron</groupId>
-            <artifactId>heron-storm</artifactId>
-            <version>${heron.version}</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.zookeeper</groupId>
-            <artifactId>zookeeper</artifactId>
-            <version>${zookeeper.heron.version}</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
-            <version>${slf4j-log4j12.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.googlecode.json-simple</groupId>
-            <artifactId>json-simple</artifactId>
-            <version>1.1</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.thrift</groupId>
-            <artifactId>libthrift</artifactId>
-            <version>0.11.0</version>
-        </dependency>
-    </dependencies>
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.samoa</groupId>
+      <artifactId>samoa-api</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.samoa</groupId>
+      <artifactId>samoa-test</artifactId>
+      <type>test-jar</type>
+      <classifier>test-jar-with-dependencies</classifier>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
     <dependency>
       <groupId>com.twitter.heron</groupId>
       <artifactId>heron-storm</artifactId>
@@ -111,6 +82,16 @@
       <artifactId>slf4j-log4j12</artifactId>
       <version>${slf4j-log4j12.version}</version>
       <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.googlecode.json-simple</groupId>
+      <artifactId>json-simple</artifactId>
+      <version>1.1</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.thrift</groupId>
+      <artifactId>libthrift</artifactId>
+      <version>0.11.0</version>
     </dependency>
   </dependencies>
 
@@ -159,12 +140,12 @@
       </plugin>
     </plugins>
    <testResources>
-      <testResource>
-	<directory>${project.basedir}/../bin</directory>
-	<includes>
-	<include>*heron.properties</include>
-	</includes>
-      </testResource>
+    <testResource>
+      <directory>${project.basedir}/../bin</directory>
+      <includes>
+        <include>*heron.properties</include>
+      </includes>
+    </testResource>
    </testResources>
   </build>
 </project>


### PR DESCRIPTION
After this PR, this is the end of the output of command "mvn -Pheron package"


Tests in error:
  AlgosTest.testVHTWithHeron »  test timed out after 60000 milliseconds
  HeronProcessingItemTest.testAddToTopology:62 » IllegalArgument Value of type b...


Tests run: 4, Failures: 0, Errors: 2, Skipped: 2

[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary:
[INFO]
[INFO] Apache SAMOA 0.5.0-incubating-SNAPSHOT ............. SUCCESS [  3.747 s]
[INFO] samoa-instances .................................... SUCCESS [  2.090 s]
[INFO] samoa-api .......................................... SUCCESS [ 49.460 s]
[INFO] samoa-test ......................................... SUCCESS [  2.607 s]
[INFO] samoa-heron 0.5.0-incubating-SNAPSHOT .............. FAILURE [01:05 min]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 02:03 min
[INFO] Finished at: 2018-11-01T23:32:32-07:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-surefire-plugin:2.18:test (default-test) on project samoa-heron: There are test failures.